### PR TITLE
implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,26 @@ The Cloud Foundry JDBC Buildpack is a Cloud Native Buildpack V3 that provides JD
 This buildpack is designed to work in collaboration with other buildpacks.
 
 ## Detection
+The detection phase passes if:
 
+* A service is bound with a payload containing a `binding_name`, `instance_name`, `label`, or `tag` containing either `mariadb` or `mysql` as a substring and build plan contains `jvm-application`
+* and the application does not contain either mariadb-java-client-_version_.jar or mysql-connector-java-_version_.jar
+    * Contributes `mariadb-jdbc` to the build plan
+
+* A service is bound with a payload containing a `binding_name`, `instance_name`, `label`, or `tag` containing `postgres` as a substring and build plan contains `jvm-application`
+* and the application does not contain postgresql-_version_.jar
+    * Contributes `postgresql-jdbc` to the build plan
+    
 ## Build
+If the build plan contains
+
+* `mariadb-jdbc`
+  * Contributes the MariaDB JDBC Driver to a layer marked `launch`
+  * Adds the MariaDB JDBC Driver to the classpath
+
+* `postgresql-jdbc`
+  * Contributes the PostgreSQL JDBC Driver to a layer marked `launch`
+  * Adds the PostgreSQL JDBC Driver to the classpath
 
 ## License
 This buildpack is released under version 2.0 of the [Apache License][a].

--- a/build/main.go
+++ b/build/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/buildpack/libbuildpack/buildplan"
+	"github.com/cloudfoundry/jdbc-cnb/jdbc"
 	"github.com/cloudfoundry/libcfbuildpack/build"
 )
 
@@ -40,5 +41,25 @@ func main() {
 }
 
 func b(build build.Build) (int, error) {
+	build.Logger.FirstLine(build.Logger.PrettyIdentity(build.Buildpack))
+
+	m, okm, err := jdbc.NewMariaDB(build)
+	if err != nil {
+		return build.Failure(102), err
+	} else if okm {
+		if err := m.Contribute(); err != nil {
+			return build.Failure(103), err
+		}
+	}
+
+	p, okp, err := jdbc.NewPostgreSQL(build)
+	if err != nil {
+		return build.Failure(102), err
+	} else if okp {
+		if err := p.Contribute(); err != nil {
+			return build.Failure(103), err
+		}
+	}
+
 	return build.Success(buildplan.BuildPlan{})
 }

--- a/detect/main.go
+++ b/detect/main.go
@@ -40,7 +40,10 @@ func main() {
 		os.Exit(101)
 	}
 
-	// TODO: Do I need build plan here?
+	if err := detect.BuildPlan.Init(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "Failed to initialize Build Plan: %s\n", err)
+		os.Exit(101)
+	}
 
 	if code, err := d(detect); err != nil {
 		detect.Logger.Info(err.Error())
@@ -60,16 +63,15 @@ func d(detect detect.Detect) (int, error) {
 			} else if !ok {
 				bp[jdbc.MariaDBDependency] = detect.BuildPlan[jdbc.MariaDBDependency]
 			}
-		} else if detect.Services.HasService("postgres") {
+		}
+
+		if detect.Services.HasService("postgres") {
 			if ok, err := helper.HasFile(detect.Application.Root, pp); err != nil {
 				return detect.Error(102), err
 			} else if !ok {
 				bp[jdbc.PostgreSQLDependency] = detect.BuildPlan[jdbc.PostgreSQLDependency]
 			}
-		} else {
-			return detect.Fail(), nil
 		}
-
 	}
 
 	if reflect.DeepEqual(bp, buildplan.BuildPlan{}) {

--- a/detect/main_test.go
+++ b/detect/main_test.go
@@ -46,9 +46,15 @@ func TestDetect(t *testing.T) {
 			g.Expect(d(f.Detect)).To(Equal(detect.FailStatusCode))
 		})
 
-		it("passes with mariadb service", func() {
-			f.AddBuildPlan(jvmapplication.Dependency, buildplan.Dependency{})
+		it("fails without jvm-application", func() {
 			f.AddService("mariadb", services.Credentials{"test-key": "test-value"})
+
+			g.Expect(d(f.Detect)).To(Equal(detect.FailStatusCode))
+		})
+
+		it("passes with mariadb service", func() {
+			f.AddService("mariadb", services.Credentials{"test-key": "test-value"})
+			f.AddBuildPlan(jvmapplication.Dependency, buildplan.Dependency{})
 
 			g.Expect(d(f.Detect)).To(Equal(detect.PassStatusCode))
 		})
@@ -71,6 +77,14 @@ func TestDetect(t *testing.T) {
 			f.AddBuildPlan(jvmapplication.Dependency, buildplan.Dependency{})
 			f.AddService("mariadb", services.Credentials{"test-key": "test-value"})
 			test.TouchFile(t, f.Detect.Application.Root, "mariadb-java-client-1.2.3.jar")
+
+			g.Expect(d(f.Detect)).To(Equal(detect.FailStatusCode))
+		})
+
+		it("fails with mysql service and a matching jar available", func() {
+			f.AddBuildPlan(jvmapplication.Dependency, buildplan.Dependency{})
+			f.AddService("mysql", services.Credentials{"test-key": "test-value"})
+			test.TouchFile(t, f.Detect.Application.Root, "mysql-connector-java-1.2.3.jar")
 
 			g.Expect(d(f.Detect)).To(Equal(detect.FailStatusCode))
 		})

--- a/jdbc/mariadb.go
+++ b/jdbc/mariadb.go
@@ -26,7 +26,7 @@ import (
 )
 
 // MariaDBDependency indicates that a JVM application should be run with MariaDB JDBC enabled.
-const MariaDBDependency = "jdbc-mariadb"
+const MariaDBDependency = "mariadb-jdbc"
 
 // MariaDB represents a MariaDB contribution by the buildpack.
 type MariaDB struct {

--- a/jdbc/mariadb_test.go
+++ b/jdbc/mariadb_test.go
@@ -64,7 +64,7 @@ func TestMariaDB(t *testing.T) {
 
 			g.Expect(y.Contribute()).To(Succeed())
 
-			layer := f.Build.Layers.Layer("jdbc-mariadb")
+			layer := f.Build.Layers.Layer("mariadb-jdbc")
 			g.Expect(layer).To(test.HaveLayerMetadata(false, false, true))
 			g.Expect(filepath.Join(layer.Root, "stub-mariadb-java-client.jar")).To(BeARegularFile())
 			g.Expect(layer).To(test.HaveAppendPathLaunchEnvironment("CLASSPATH", ":%s",

--- a/jdbc/postgresql.go
+++ b/jdbc/postgresql.go
@@ -26,7 +26,7 @@ import (
 )
 
 // PostgreSQLDependency indicates that a JVM application should be run with PostgreSQL JDBC enabled.
-const PostgreSQLDependency = "jdbc-postgresql"
+const PostgreSQLDependency = "postgresql-jdbc"
 
 // PostgreSQL represents a PostgreSQL contribution by the buildpack.
 type PostgreSQL struct {
@@ -44,7 +44,7 @@ func (p PostgreSQL) Contribute() error {
 			return err
 		}
 
-		return layer.AppendPathLaunchEnv("CLASSPATH", ":%s", destination)
+		return layer.AppendPathLaunchEnv("CLASSPATH", "%s", destination)
 	}, layers.Launch)
 }
 

--- a/jdbc/postgresql_test.go
+++ b/jdbc/postgresql_test.go
@@ -64,10 +64,10 @@ func TestPostgreSQL(t *testing.T) {
 
 			g.Expect(y.Contribute()).To(Succeed())
 
-			layer := f.Build.Layers.Layer("jdbc-postgresql")
+			layer := f.Build.Layers.Layer("postgresql-jdbc")
 			g.Expect(layer).To(test.HaveLayerMetadata(false, false, true))
 			g.Expect(filepath.Join(layer.Root, "stub-postgresql.jar")).To(BeARegularFile())
-			g.Expect(layer).To(test.HaveAppendPathLaunchEnvironment("CLASSPATH", ":%s",
+			g.Expect(layer).To(test.HaveAppendPathLaunchEnvironment("CLASSPATH", "%s",
 				filepath.Join(layer.Root, "stub-postgresql.jar")))
 		})
 	}, spec.Report(report.Terminal{}))


### PR DESCRIPTION
This change adds an implementation that looks for a bound MariaDB/MySQL or
PostgreSQL service. If one is found, and the application does not already
contain a corresponding JDBC driver, it contributes the corresponding driver
and adds it to the classpath.